### PR TITLE
Moved prevColours definition outside loop.

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -39,9 +39,9 @@ $(document).ready(function () {
   $("#currentDay").text(moment().format("hh:mm A, dddd Do MMMM"));
 
   // ## After 1s, and every second thereafter, update the current time and detect if the correct colours are displayed (which will take effect if the current hour changes):
+  var prevColours;
   $(setInterval(function () {
     $("#currentDay").text(moment().format("hh:mm A, dddd Do MMMM"));
-    var prevColours;
     if (prevColours !== moment().hour()) {
       colours();
       prevColours = moment().hour();


### PR DESCRIPTION
Moved `var prevColours;` definition outside of the `setInterval` loop to fix the error in the logic.